### PR TITLE
use type parameter for E matrix

### DIFF
--- a/src/connections.jl
+++ b/src/connections.jl
@@ -35,7 +35,7 @@ of individual systems. This corresponds to the block diagonal concatenation of
 their transfer function matrices. 
 Appending systems with constant matrices, vectors or scalars or with UniformScalings is also supported. 
 """
-function append(systems::(DST where DST<:DescriptorStateSpace)...)
+function append(systems::DescriptorStateSpace...)
     T = promote_type(eltype.(systems)...)
     Ts = systems[1].Ts
     if !all(s.Ts == Ts for s in systems)
@@ -116,8 +116,8 @@ concatenation of their transfer function matrices.
 Concatenation of systems with constant matrices, vectors, or scalars having the same row dimensions 
 or with UniformScalings is also supported.  
 """
-horzcat(systems::Union{DST,AbstractNumOrArray,UniformScaling}...) where DST <: DescriptorStateSpace = hcat(systems...)
-function Base.hcat(systems::DST...) where DST <: DescriptorStateSpace
+horzcat(systems::Union{DescriptorStateSpace,AbstractNumOrArray,UniformScaling}...) = hcat(systems...)
+function Base.hcat(systems::DescriptorStateSpace...)
     # Perform checks
     T = promote_type(eltype.(systems)...)
     Ts = systems[1].Ts
@@ -151,9 +151,9 @@ concatenation of their transfer function matrices.
 Concatenation of systems with constant matrices, vectors, or scalars having the same column dimensions 
 or with UniformScalings is also supported.  
 """
-vertcat(systems::Union{DST,AbstractNumOrArray,UniformScaling}...) where DST <: DescriptorStateSpace = vcat(systems...)
+vertcat(systems::Union{DescriptorStateSpace,AbstractNumOrArray,UniformScaling}...) = vcat(systems...)
 
-function Base.vcat(systems::DST...) where DST <: DescriptorStateSpace
+function Base.vcat(systems::DescriptorStateSpace...)
     # Perform checks
     T = promote_type(eltype.(systems)...)
     Ts = systems[1].Ts

--- a/src/types/DescriptorStateSpace.jl
+++ b/src/types/DescriptorStateSpace.jl
@@ -27,17 +27,17 @@ defined by the 4-tuple `SYS = (A-λE,B,C,D)`, then:
 
 The dimensions `nx`, `ny` and `nu` can be obtained as `SYS.nx`, `SYS.ny` and `SYS.nu`, respectively. 
 """
-struct DescriptorStateSpace{T} <: AbstractDescriptorStateSpace 
+struct DescriptorStateSpace{T, ET <: Union{Matrix{T},UniformScaling}} <: AbstractDescriptorStateSpace 
     A::Matrix{T}
-    E::Union{Matrix{T},UniformScaling}
+    E::ET
     B::Matrix{T}
     C::Matrix{T}
     D::Matrix{T}
     Ts::Float64
     function DescriptorStateSpace{T}(A::Matrix{T}, E::Union{Matrix{T},UniformScaling}, 
-                                     B::Matrix{T}, C::Matrix{T}, D::Matrix{T},  Ts::Real) where T 
+                                     B::Matrix{T}, C::Matrix{T}, D::Matrix{T},  Ts::Real) where {T} 
         dss_validation(A, E, B, C, D, Ts)
-        new{T}(A, E, B, C, D, Float64(Ts))
+        new{T, typeof(E)}(A, E, B, C, D, Float64(Ts))
     end
 end
 function dss_validation(A::Matrix{T}, E::Union{Matrix{T},UniformScaling}, 


### PR DESCRIPTION
If the field `E` is not associated with a type parameter, each access of `E` is type unstable, leading to a lot of inference problems and long compile times. This change brings a simple benchmark I have (using RobustAndOptimalControl which calls `ghinfnorm` in this package`) from 
```julia
julia> using RobustAndOptimalControl, ControlSystems

julia> G = ssrand(2,2,2);

julia> @time hinfnorm2(G);
 18.141708 seconds (50.01 M allocations: 2.384 GiB, 8.45% gc time, 99.97% compilation time)
```
to
```
julia> @time hinfnorm2(G);
  6.451567 seconds (26.34 M allocations: 1.337 GiB, 7.95% gc time, 99.99% compilation time)
```

This is a step towards addressing the latest findings from 
- https://github.com/andreasvarga/DescriptorSystems.jl/issues/9