### PR TITLE
Improve inference of `getproperty`

### DIFF
--- a/src/types/DescriptorStateSpace.jl
+++ b/src/types/DescriptorStateSpace.jl
@@ -61,11 +61,11 @@ function dss_validation(A::Matrix{T}, E::Union{Matrix{T},UniformScaling},
 end
 function Base.getproperty(sys::DescriptorStateSpace, d::Symbol)  
     if d === :nx
-        return size(sys.A,1)
+        return size(getfield(sys, :A), 1)
     elseif d === :ny
-        return size(sys.C,1)
+        return size(getfield(sys, :C), 1)
     elseif d === :nu
-        return size(sys.B,2)
+        return size(getfield(sys, :B), 2)
     else
         getfield(sys, d)
     end


### PR DESCRIPTION
This PR prevents recursion into `getproperty` when accessing fields `A,B,C`, leading to improvements in inference when accessing, e.g., the `ny` property.

Before:
```julia
julia> foo(G) = G.ny
foo (generic function with 1 method)

julia> @code_warntype foo(G)
MethodInstance for foo(::DescriptorStateSpace{Float64, LinearAlgebra.UniformScaling{Bool}})
  from foo(G) in Main at REPL[12]:1
Arguments
  #self#::Core.Const(foo)
  G::DescriptorStateSpace{Float64, LinearAlgebra.UniformScaling{Bool}}
Body::Any
1 ─ %1 = Base.getproperty(G, :ny)::Any
└──      return %1
```

After:
```julia
julia> foo(G) = G.ny
foo (generic function with 1 method)

julia> G = rss(2,2,4);

julia> @code_warntype foo(G)
MethodInstance for foo(::DescriptorStateSpace{Float64, LinearAlgebra.UniformScaling{Bool}})
  from foo(G) in Main at REPL[2]:1
Arguments
  #self#::Core.Const(foo)
  G::DescriptorStateSpace{Float64, LinearAlgebra.UniformScaling{Bool}}
Body::Int64
1 ─ %1 = Base.getproperty(G, :ny)::Int64
└──      return %1
```

Since a lot of functions access the `ny` property very early, this type instability poisons the entire function with type instability leading to long compile times.