### PR TITLE
make hcat/vcat inferrable in some cases

### DIFF
--- a/src/connections.jl
+++ b/src/connections.jl
@@ -72,7 +72,7 @@ function hcat(SYS1::DescriptorStateSpace{T1, TE1}, SYS2::DescriptorStateSpace{T2
     ny = SYS1.ny
     ny == size(SYS2, 1) ||  error("The systems must have the same output dimension")
     T = promote_type(T1, T2)
-    TE = promote_type(TE1, TE2)
+    TE = promote_Etype(TE1, TE2)
     Ts = promote_Ts(SYS1.Ts, SYS2.Ts) 
 
     A = blockdiag(T.(SYS1.A), T.(SYS2.A))
@@ -180,7 +180,7 @@ function vcat(SYS1::DescriptorStateSpace{T1, TE1}, SYS2::DescriptorStateSpace{T2
     nu = SYS1.nu
     nu == size(SYS2, 2) ||  error("The systems must have the same input dimension")
     T = promote_type(T1, T2)
-    TE = promote_type(TE1, TE2)
+    TE = promote_Etype(TE1, TE2)
     Ts = promote_Ts(SYS1.Ts, SYS2.Ts) 
 
     A = blockdiag(T.(SYS1.A), T.(SYS2.A))

--- a/src/connections.jl
+++ b/src/connections.jl
@@ -77,7 +77,7 @@ function hcat(SYS1::DescriptorStateSpace{T1, TE1}, SYS2::DescriptorStateSpace{T2
 
     A = blockdiag(T.(SYS1.A), T.(SYS2.A))
     local E::TE
-    if SYS1.E == I && SYS2.E == I 
+    if SYS1.E === I && SYS2.E === I 
         E = I 
     elseif SYS1.E == I || SYS2.E == I 
         blockdims = [size(SYS1.A,1), size(SYS2.A,1)]
@@ -185,7 +185,7 @@ function vcat(SYS1::DescriptorStateSpace{T1, TE1}, SYS2::DescriptorStateSpace{T2
 
     A = blockdiag(T.(SYS1.A), T.(SYS2.A))
     local E::TE
-    if SYS1.E == I && SYS2.E == I 
+    if SYS1.E === I && SYS2.E === I 
         E = I 
     elseif SYS1.E == I || SYS2.E == I 
         blockdims = [size(SYS1.A,1), size(SYS2.A,1)]

--- a/src/connections.jl
+++ b/src/connections.jl
@@ -68,14 +68,15 @@ function append(A::Union{DescriptorStateSpace,AbstractNumOrArray,UniformScaling}
 end
 
 
-function hcat(SYS1 :: DescriptorStateSpace, SYS2 :: DescriptorStateSpace)
+function hcat(SYS1::DescriptorStateSpace{T1, TE1}, SYS2::DescriptorStateSpace{T2, TE2}) where {T1<:Number, TE1<:ETYPE, T2<:Number, TE2<:ETYPE}
     ny = SYS1.ny
     ny == size(SYS2, 1) ||  error("The systems must have the same output dimension")
-    T = promote_type(eltype(SYS1), eltype(SYS2))
+    T = promote_type(T1, T2)
+    TE = promote_type(TE1, TE2)
     Ts = promote_Ts(SYS1.Ts, SYS2.Ts) 
 
     A = blockdiag(T.(SYS1.A), T.(SYS2.A))
-  
+    local E::TE
     if SYS1.E == I && SYS2.E == I 
         E = I 
     elseif SYS1.E == I || SYS2.E == I 
@@ -175,14 +176,15 @@ function Base.vcat(systems::DescriptorStateSpace...)
     return DescriptorStateSpace{T}(A, E, B, C, D, Ts)
 end
 
-function vcat(SYS1 :: DescriptorStateSpace, SYS2 :: DescriptorStateSpace)
+function vcat(SYS1::DescriptorStateSpace{T1, TE1}, SYS2::DescriptorStateSpace{T2, TE2}) where {T1<:Number, TE1<:ETYPE, T2<:Number, TE2<:ETYPE}
     nu = SYS1.nu
     nu == size(SYS2, 2) ||  error("The systems must have the same input dimension")
-    T = promote_type(eltype(SYS1), eltype(SYS2))
+    T = promote_type(T1, T2)
+    TE = promote_type(TE1, TE2)
     Ts = promote_Ts(SYS1.Ts, SYS2.Ts) 
 
     A = blockdiag(T.(SYS1.A), T.(SYS2.A))
-  
+    local E::TE
     if SYS1.E == I && SYS2.E == I 
         E = I 
     elseif SYS1.E == I || SYS2.E == I 

--- a/src/types/DescriptorStateSpace.jl
+++ b/src/types/DescriptorStateSpace.jl
@@ -1,6 +1,6 @@
 #const AbstractNumOrArray = Union{AbstractVecOrMat{T},Number} where {T <: Number}
 const AbstractNumOrArray = Union{AbstractVecOrMat,Number}
-const ETYPE{T} = Union{Matrix{T},UniformScaling}
+const ETYPE{T} = Union{Matrix{T},UniformScaling{Bool}}
 """ 
     DescriptorStateSpace{T}(A::Matrix{T}, E::Union{Matrix{T},UniformScaling}, 
                             B::Matrix{T}, C::Matrix{T}, D::Matrix{T},  

--- a/src/types/DescriptorStateSpace.jl
+++ b/src/types/DescriptorStateSpace.jl
@@ -1,6 +1,11 @@
 #const AbstractNumOrArray = Union{AbstractVecOrMat{T},Number} where {T <: Number}
 const AbstractNumOrArray = Union{AbstractVecOrMat,Number}
 const ETYPE{T} = Union{Matrix{T},UniformScaling{Bool}}
+promote_Etype(::Type{UniformScaling{Bool}}, ::Type{UniformScaling{Bool}}) = UniformScaling{Bool}
+promote_Etype(T1::Type, ::Type{UniformScaling{Bool}}) = T1
+promote_Etype(::Type{UniformScaling{Bool}}, T2::Type) = T2
+promote_Etype(T1::Type, T2::Type) = promote_type(T1, T2)
+
 """ 
     DescriptorStateSpace{T}(A::Matrix{T}, E::Union{Matrix{T},UniformScaling}, 
                             B::Matrix{T}, C::Matrix{T}, D::Matrix{T},  

--- a/src/types/DescriptorStateSpace.jl
+++ b/src/types/DescriptorStateSpace.jl
@@ -1,5 +1,6 @@
 #const AbstractNumOrArray = Union{AbstractVecOrMat{T},Number} where {T <: Number}
 const AbstractNumOrArray = Union{AbstractVecOrMat,Number}
+const ETYPE{T} = Union{Matrix{T},UniformScaling}
 """ 
     DescriptorStateSpace{T}(A::Matrix{T}, E::Union{Matrix{T},UniformScaling}, 
                             B::Matrix{T}, C::Matrix{T}, D::Matrix{T},  
@@ -27,20 +28,20 @@ defined by the 4-tuple `SYS = (A-λE,B,C,D)`, then:
 
 The dimensions `nx`, `ny` and `nu` can be obtained as `SYS.nx`, `SYS.ny` and `SYS.nu`, respectively. 
 """
-struct DescriptorStateSpace{T, ET <: Union{Matrix{T},UniformScaling}} <: AbstractDescriptorStateSpace 
+struct DescriptorStateSpace{T, ET <: ETYPE{T}} <: AbstractDescriptorStateSpace 
     A::Matrix{T}
     E::ET
     B::Matrix{T}
     C::Matrix{T}
     D::Matrix{T}
     Ts::Float64
-    function DescriptorStateSpace{T}(A::Matrix{T}, E::Union{Matrix{T},UniformScaling}, 
+    function DescriptorStateSpace{T}(A::Matrix{T}, E::ETYPE{T}, 
                                      B::Matrix{T}, C::Matrix{T}, D::Matrix{T},  Ts::Real) where {T} 
         dss_validation(A, E, B, C, D, Ts)
         new{T, typeof(E)}(A, E, B, C, D, Float64(Ts))
     end
 end
-function dss_validation(A::Matrix{T}, E::Union{Matrix{T},UniformScaling}, 
+function dss_validation(A::Matrix{T}, E::ETYPE{T}, 
                         B::Matrix{T}, C::Matrix{T}, D::Matrix{T},  Ts::Real) where T
     nx = LinearAlgebra.checksquare(A)
     (ny, nu) = size(D)

--- a/test/test_connections.jl
+++ b/test/test_connections.jl
@@ -12,11 +12,22 @@ println("Test_connections")
 @testset "Standard state space" begin
 # CONTINUOUS
 C_111 = dss([1], [2], [3], [4])
+C_111E = dss([1], [1], [2], [3], [4])
 C_211 = dss(eye(2), [1; 2], [1 0], [0])
 C_212 = dss(eye(2), [1; 2], eye(2), [0; 0])
 C_221 = dss(eye(2), [1 0; 0 2], [1 0], [0 0])
 C_222 = dss(eye(2), [1 0; 0 2], eye(2), zeros(Int,2,2))
 C_022 = dss(4*eye(2))
+
+@test [C_111 C_111] isa DescriptorStateSpace{Int, UniformScaling{Bool}}
+@test [C_111 C_111E] isa DescriptorStateSpace{Int, Matrix{Int}}
+@test [C_111E C_111E] isa DescriptorStateSpace{Int, Matrix{Int}}
+@test [C_111E C_111] isa DescriptorStateSpace{Int, Matrix{Int}}
+
+@inferred hcat(C_111, C_111)
+@inferred hcat(C_111, C_111E)
+@inferred hcat(C_111E, C_111E)
+@inferred hcat(C_111E, C_111)
 
 # DISCRETE
 D_111 = dss([1], [2], [3], [4], Ts = 0.005)


### PR DESCRIPTION
This PR makes julia's inference capable of inferring the type of `E` when concatenation like `[G I]` occurs, notice the difference in the inferred type of the result changing from 
```julia
DescriptorSystems.DescriptorStateSpace{Float64, _A} where _A<:Union{UniformScaling, Matrix{Float64}}
```
to
```julia
DescriptorSystems.DescriptorStateSpace{Float64, UniformScaling{Bool}}
```


Before
```julia
julia> @code_warntype [G I]
MethodInstance for hcat(::DescriptorSystems.DescriptorStateSpace{Float64, UniformScaling{Bool}}, ::UniformScaling{Bool})
  from hcat(SYS::DescriptorSystems.DescriptorStateSpace, MAT::UniformScaling) in DescriptorSystems at /home/fredrikb/.julia/dev/DescriptorSystems/src/connections.jl:96
Arguments
  #self#::Core.Const(hcat)
  SYS::DescriptorSystems.DescriptorStateSpace{Float64, UniformScaling{Bool}}
  MAT::UniformScaling{Bool}
Body::DescriptorSystems.DescriptorStateSpace{Float64, _A} where _A<:Union{UniformScaling, Matrix{Float64}}
1 ─ %1  = DescriptorSystems.eltype(SYS)::Core.Const(Float64)
│   %2  = DescriptorSystems.eltype(MAT)::Core.Const(Bool)
│   %3  = DescriptorSystems.promote_type(%1, %2)::Core.Const(Float64)
│   %4  = Core.apply_type(DescriptorSystems.Matrix, %3)::Core.Const(Matrix{Float64})
│   %5  = Base.getproperty(SYS, :ny)::Int64
│   %6  = Base.getproperty(SYS, :ny)::Int64
│   %7  = (%4)(MAT, %5, %6)::Matrix{Float64}
│   %8  = (:Ts,)::Core.Const((:Ts,))
│   %9  = Core.apply_type(Core.NamedTuple, %8)::Core.Const(NamedTuple{(:Ts,)})
│   %10 = Base.getproperty(SYS, :Ts)::Float64
│   %11 = Core.tuple(%10)::Tuple{Float64}
│   %12 = (%9)(%11)::NamedTuple{(:Ts,), Tuple{Float64}}
│   %13 = Core.kwfunc(DescriptorSystems.dss)::Core.Const(DescriptorSystems.var"#dss##kw"())
│   %14 = (%13)(%12, DescriptorSystems.dss, %7)::Core.PartialStruct(DescriptorSystems.DescriptorStateSpace{Float64, UniformScaling{Bool}}, Any[Matrix{Float64}, Core.Const(UniformScaling{Bool}(true)), Matrix{Float64}, Matrix{Float64}, Matrix{Float64}, Float64])
│   %15 = DescriptorSystems.hcat(SYS, %14)::DescriptorSystems.DescriptorStateSpace{Float64, _A} where _A<:Union{UniformScaling, Matrix{Float64}}
└──       return %15

```

After:
```julia
julia> @code_warntype [G I]
MethodInstance for hcat(::DescriptorSystems.DescriptorStateSpace{Float64, UniformScaling{Bool}}, ::UniformScaling{Bool})
  from hcat(SYS::DescriptorSystems.DescriptorStateSpace, MAT::UniformScaling) in DescriptorSystems at /home/fredrikb/.julia/dev/DescriptorSystems/src/connections.jl:96
Arguments
  #self#::Core.Const(hcat)
  SYS::DescriptorSystems.DescriptorStateSpace{Float64, UniformScaling{Bool}}
  MAT::UniformScaling{Bool}
Body::DescriptorSystems.DescriptorStateSpace{Float64, UniformScaling{Bool}}
1 ─ %1  = DescriptorSystems.eltype(SYS)::Core.Const(Float64)
│   %2  = DescriptorSystems.eltype(MAT)::Core.Const(Bool)
│   %3  = DescriptorSystems.promote_type(%1, %2)::Core.Const(Float64)
│   %4  = Core.apply_type(DescriptorSystems.Matrix, %3)::Core.Const(Matrix{Float64})
│   %5  = Base.getproperty(SYS, :ny)::Int64
│   %6  = Base.getproperty(SYS, :ny)::Int64
│   %7  = (%4)(MAT, %5, %6)::Matrix{Float64}
│   %8  = (:Ts,)::Core.Const((:Ts,))
│   %9  = Core.apply_type(Core.NamedTuple, %8)::Core.Const(NamedTuple{(:Ts,)})
│   %10 = Base.getproperty(SYS, :Ts)::Float64
│   %11 = Core.tuple(%10)::Tuple{Float64}
│   %12 = (%9)(%11)::NamedTuple{(:Ts,), Tuple{Float64}}
│   %13 = Core.kwfunc(DescriptorSystems.dss)::Core.Const(DescriptorSystems.var"#dss##kw"())
│   %14 = (%13)(%12, DescriptorSystems.dss, %7)::Core.PartialStruct(DescriptorSystems.DescriptorStateSpace{Float64, UniformScaling{Bool}}, Any[Matrix{Float64}, Core.Const(UniformScaling{Bool}(true)), Matrix{Float64}, Matrix{Float64}, Matrix{Float64}, Float64])
│   %15 = DescriptorSystems.hcat(SYS, %14)::DescriptorSystems.DescriptorStateSpace{Float64, UniformScaling{Bool}}
└──       return %15
```


This brings the compile time of `ghinfnorm` down further to
```
julia> @time ghinfnorm(G);
  5.237686 seconds (15.39 M allocations: 757.740 MiB, 10.67% gc time, 100.00% compilation time)
```
compared to [before](https://github.com/andreasvarga/DescriptorSystems.jl/pull/12#issuecomment-1063771310), which was 
```
julia> @time ghinfnorm(G);
  6.971881 seconds (24.47 M allocations: 1.197 GiB, 10.94% gc time, 99.99% compilation time)
```